### PR TITLE
Add workflows and fix spelling

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,32 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Node.js CI
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x, 20.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci --force
+    - run: npm run build --if-present

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: npm ci --force
-      - run: npm run build --if-present
+      - run: npm run build --if-present --isNpmBuild
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,35 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Publish Node.js Package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci --force
+      - run: npm run build --if-present
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci --force
+      - run: npm run build --if-present
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/build/build.js
+++ b/build/build.js
@@ -89,7 +89,7 @@ let rollupError = false;
 
     // Read license.txt to define the banner for the packages.
     let banner = "/*\n";
-    banner += (await fs.readFile("./license.md", "utf8")).trim();
+    banner += (await fs.readFile("./LICENSE.md", "utf8")).trim();
     banner += "\n*/\n";
 
     let rollupInputOps, rollupOutputOps;

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "files": [
     "typings/**/*",
     "dist/**/*",
-    "license.md"
+    "LICENSE.md"
   ],
   "types": "typings/index.d.ts",
   "main": "dist/azure-maps-gridded-data-source.min.js"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Added ```Node.js CI``` workflow.
This workflow builds the package using Node.js versions 14, 16, 18, and 20 on every push to any branch.
* Added ``Publish Nodes.js Package`` workflow.
This workflow publishes the package to npm whenever a release is published. It also supports manual triggering.
Notice the secret ```npm_token``` has to be set in the repository.
* Minor fixes
Modify the case of certain words (specifically uppercase ```LICENSE.md``` instead of ```license.md``` in ```build/build.js``` and ```package.json```) to ensure compatibility with case-sensitive environments.