### PR TITLE
Add --access=public to npm publish command

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,6 +30,6 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci --force
       - run: npm run build --if-present --isNpmBuild
-      - run: npm publish
+      - run: npm publish --access=public
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
The default access for packages with scope (i.e. ```@azure-maps/```) is private so we have to set it to public when publishing.